### PR TITLE
fix(index.wxss): 修复 CSS Parse Error [,]

### DIFF
--- a/wxParser/index.wxss
+++ b/wxParser/index.wxss
@@ -3,8 +3,7 @@
  */
 
 .wxParser-div,
-.wxParser-p,
-{
+.wxParser-p {
   word-break: break-all;
   overflow: auto;
   max-width: 100%;


### PR DESCRIPTION
W3C CSS Validator results for TextArea (CSS level 2.1)

Sorry! We found the following errors (2)

URI : TextArea
2	.wxParser-div, .wxParser-p	Parse Error [,]
4	.wxParser-div, .wxParser-p	Property word-break doesn't exist in CSS level 2.1 but exists in : break-all break-all

Valid CSS information

```css
.wxParser-div, .wxParser-p {
  overflow : auto;
  max-width : 100%;
}
```